### PR TITLE
Allow setting which host R version is used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
+-include ~/.webr-vars.mk
+
 R_VERSION = 4.1
 
 .PHONY: repo
 repo:
 	mkdir -p repo/src/contrib lib
 	R_VERSION=$(R_VERSION) \
-	  Rscript repo-update.R
+	  $(R_HOST)/bin/Rscript repo-update.R
 
 .PHONY: pkg-%
 pkg-%:
 	make clean-$*
 	mkdir -p repo/src/contrib lib
 	R_VERSION=$(R_VERSION) \
-	  Rscript repo-update.R $*
+	  $(R_HOST)/bin/Rscript repo-update.R $*
 
 .PHONY: clean
 clean:
@@ -26,5 +28,5 @@ clean-%:
 
 .PHONY: PACKAGES
 PACKAGES:
-	Rscript -e "tools::write_PACKAGES('repo/src/contrib', verbose = TRUE)"
-	Rscript -e "tools::write_PACKAGES('repo/bin//emscripten/contrib/$(R_VERSION)', type = 'mac.binary', verbose = TRUE)"
+	$(R_HOST)/bin/Rscript -e "tools::write_PACKAGES('repo/src/contrib', verbose = TRUE)"
+	$(R_HOST)/bin/Rscript -e "tools::write_PACKAGES('repo/bin/emscripten/contrib/$(R_VERSION)', type = 'mac.binary', verbose = TRUE)"

--- a/webr-build.sh
+++ b/webr-build.sh
@@ -24,7 +24,8 @@ tar xvf $TARBALL
 # otherwise R might try to load wasm packages from the library and fail
 mkdir lib
 
-R CMD INSTALL --build --library="lib" "${PKG_NAME}" \
+source $HOME/.webr-vars.mk
+$R_HOST/bin/R CMD INSTALL --build --library="lib" "${PKG_NAME}" \
   --no-docs \
   --no-test-load \
   --no-staged-install \

--- a/webr-vars.mk
+++ b/webr-vars.mk
@@ -6,6 +6,8 @@
 #   Flang's dev-ir branch
 #
 # - `WEBR_LOCAL` to the installation directory of webR
+#
+# - `R_HOST` to the installation directory of a host R build
 -include ~/.webr-vars.mk
 
 R_INCLUDES = -I$(R_SOURCE)/build/include -I$(R_SOURCE)/src/include


### PR DESCRIPTION
I think this fixed an issue where the installed system R was a different version from the version used in webR.