### PR TITLE
Allow remotes other than of type github

### DIFF
--- a/install.R
+++ b/install.R
@@ -22,6 +22,9 @@ webr_install <- function(packages, repos = "file:/repo", lib = NULL) {
     pkg_ver <- info[dep, "Version"]
     path <- file.path(repo, paste0(dep, "_", pkg_ver, ".tgz"))
 
+    tmp <- tempfile()
+    download.file(path, tmp)
+
     untar(
       path,
       exdir = lib,

--- a/repo-update.R
+++ b/repo-update.R
@@ -38,7 +38,6 @@ remotes <- unique(readLines("repo-remotes"))
 remotes_deps <- pkgdepends::new_pkg_download_proposal(remotes)
 remotes_deps$resolve()
 remotes_info <- remotes_deps$get_resolution()
-remotes_info <- remotes_info[remotes_info$type == "github", ]
 remotes_packages <- remotes_info[["package"]]
 
 # Download a remote source to src/contrib


### PR DESCRIPTION
For example, source packages on disk with a remote of "local::...".

Also download package files to tmp file before unpacking. This fixes an issue when remote is a https:// URI.