### PR TITLE
Install prerequisites to host R if required

### DIFF
--- a/repo-update.R
+++ b/repo-update.R
@@ -1,3 +1,4 @@
+host_packages = installed.packages()
 args <- commandArgs(trailingOnly = TRUE)
 
 if (length(args)) {
@@ -118,6 +119,10 @@ for (pkg in packages) {
     tarball_path <- file.path(webr_contrib_src, tarball_file)
     new_url <- paste0(cran_url, "src/contrib/", tarball_file)
     download.file(new_url, tarball_path)
+  }
+
+  if (!pkg %in% host_packages) {
+    install.packages(pkg)
   }
 
   if (!system2("./webr-build.sh", tarball_path)) {

--- a/repo-update.R
+++ b/repo-update.R
@@ -1,4 +1,3 @@
-host_packages = installed.packages()
 args <- commandArgs(trailingOnly = TRUE)
 
 if (length(args)) {
@@ -26,6 +25,12 @@ cran_url <- getOption("repos")[["CRAN"]]
 r_version <- Sys.getenv("R_VERSION")
 webr_contrib_src <- file.path("repo", "src", "contrib")
 webr_contrib_bin <- file.path("repo", "bin", "emscripten", "contrib", r_version)
+
+# Ensure both rlang and pkgdepends can be used
+host_packages = installed.packages()
+if (!"rlang" %in% host_packages || !"pkgdepends" %in% host_packages) {
+    install.packages(c("rlang", "pkgdepends"))
+}
 
 stopifnot(
   rlang::is_string(cran_url),


### PR DESCRIPTION
This installs a package to host R before attempting to build it for Emscripten, if it is not already there.

I think this was required because R would refuse to build a package for Emscripten if the prerequisites are not found in the host R library. By installing the packages first, it ensured the prerequisites were already there when building for Emscripten using `webr-build.sh`.