### PR TITLE
Fallback to `unzip` when `untar` fails after remotes download

### DIFF
--- a/repo-update.R
+++ b/repo-update.R
@@ -76,7 +76,7 @@ make_remote_tarball <- function(pkg, url, target) {
     # Get root folder name, necessary as it won't unzip as `pkg`
     folder_name <- unzip(source_tarball, list = TRUE)$Name[[1]]
     
-    unzip(source_tarball, exdir = file.path(tmp_dir))
+    zip::unzip(source_tarball, exdir = file.path(tmp_dir))
     
     # rename folder_name to `pkg`
     file.rename(file.path(tmp_dir, folder_name), file.path(tmp_dir, pkg))

--- a/repo-update.R
+++ b/repo-update.R
@@ -65,18 +65,30 @@ make_remote_tarball <- function(pkg, url, target) {
 
   # Recreate a new .tar.gz with the directory structure expected from
   # a source package
-  untar(
-    source_tarball,
-    exdir = file.path(tmp_dir, pkg),
-    extra = "--strip-components=1"
-  )
+  result_code <- attr(untar(source_tarball, list = TRUE), "status")
+  if (is.null(result_code) || result_code == 0L) {
+    untar(
+      source_tarball,
+      exdir = file.path(tmp_dir, pkg),
+      extra = "--strip-components=1"
+    )
+  } else {
+    # Get root folder name, necessary as it won't unzip as `pkg`
+    folder_name <- unzip(source_tarball, list = TRUE)$Name[[1]]
+    
+    unzip(source_tarball, exdir = file.path(tmp_dir))
+    
+    # rename folder_name to `pkg`
+    file.rename(file.path(tmp_dir, folder_name), file.path(tmp_dir, pkg))
+  }
+  
   unlink(source_tarball)
 
   repo_tarball <- file.path(normalizePath("repo"), target)
 
   withr::with_dir(
     tmp_dir,
-    tar(repo_tarball, compression = "gzip")
+    tar(repo_tarball, files = pkg, compression = "gzip")
   )
 }
 


### PR DESCRIPTION
## Context

In Linux-based systems the remotes download source is a zip file.

Example link in `remotes_info`: https://api.github.com/repos/r-wasm/httpuv/zipball/36410cd20d8c8feb687f4ad77299ba7bac1ddb2c

:question: Can we assume the `zip` package is installed? using `utils::unzip` doesn't preserve permissions

## Changes description

* Tests for tar file, keeping existing functionality
* Adds `unzip` as a fallback method
* Indicates the folder to re-package via `files` parameter
  * avoiding having `./` as the top directory (see screenshot)

![image](https://github.com/r-wasm/webr-repo/assets/211358/9dd69ec3-9fc2-42df-b0c1-a922e2024034)
